### PR TITLE
fix: Progress bar links changed

### DIFF
--- a/templates/codediaz.md
+++ b/templates/codediaz.md
@@ -34,21 +34,21 @@
         <img src="https://thumbs4.imagebam.com/6c/bc/6e/MESRGXI_t.png" width="90" alt="UPS.png"/><br>
         <img src="https://thumbs4.imagebam.com/d7/6e/91/MESRJ8U_t.png" height="20" alt="Ec.png"/><br>
         <strong>UPS</strong><br><strong>BSc.</strong> Computer Science<br>
-        <img src="https://progress-bar.dev/100/" width="105" alt="progress-bar"/>
+        <img src="https://geps.dev/progress/100" width="105" alt="progress-bar"/>
       </td>
       <td align="center">
        <img src="https://thumbs4.imagebam.com/b4/6b/77/MESRJT1_t.png" height="40" alt="0.png"/>
        <img src="https://thumbs4.imagebam.com/d6/0d/e4/MESRJUR_t.png" width="90" alt="TEC.png"/><br>
         <img src="https://thumbs4.imagebam.com/b9/01/da/MESRJ8V_t.png" height="20" alt="Mx.png"/><br>
         <strong>TEC</strong><br><strong>MSc.</strong> Inf. Technology Mgmt<br>
-        <img src="https://progress-bar.dev/30/" width="100" alt="progress-bar"/>
+        <img src="https://geps.dev/progress/60" width="100" alt="progress-bar"/>
       </td>
       <td align="center">
        <img src="https://thumbs4.imagebam.com/b4/6b/77/MESRJT1_t.png" height="40" alt="0.png"/>
        <img src="https://thumbs4.imagebam.com/5b/76/d8/MESRJL0_t.png" width="90" alt="MIT-C-I.png"/><br>
         <img src="https://thumbs4.imagebam.com/c8/fe/34/MESRJ8W_t.png" height="20" alt="Usa.png"/><br>
         <strong>MIT</strong><br><strong>PhD.</strong> Computer Science<br>
-        <img src="https://progress-bar.dev/0/" width="105" alt="progress-bar"/>
+        <img src="https://geps.dev/progress/0" width="105" alt="progress-bar"/>
       </td>
     </tr>
   </table>
@@ -101,4 +101,4 @@
 ------
 **Credits :** [codediaz](https://github.com/codediaz)
 
-**Last Edited on:** 06/04/2024
+**Last Edited on:** 04/01/2025


### PR DESCRIPTION
- Replaced outdated link to https://progress-bar.dev with the current link https://geps.dev/progress.