### PR TITLE
Added template for username: StaryMoon

### DIFF
--- a/_sidebar.md
+++ b/_sidebar.md
@@ -359,6 +359,7 @@
     - [ruthrootz](/templates/ruthrootz.md)
     - [RResabala2015](/templates/RResabala2015.md)
   - S
+    - [StaryMoon](/templates/StaryMoon.md)
     - [Sabihashaik](/templates/Sabihashaik.md)
     - [sahil2128](/templates/sahil2128.md)
     - [sajidul-kabir](/templates/sajidul-kabir.md)

--- a/templates/StaryMoon.md
+++ b/templates/StaryMoon.md
@@ -1,0 +1,52 @@
+# Minghao Liu
+
+Peking University student working on image restoration, deraining, continual learning, and small tools that make research life less brittle.
+
+[![GitHub followers](https://img.shields.io/github/followers/StaryMoon?style=flat&label=followers)](https://github.com/StaryMoon)
+[![DailyDesk](https://img.shields.io/github/stars/StaryMoon/DailyDesk?style=flat&label=DailyDesk)](https://github.com/StaryMoon/DailyDesk)
+[![VSCode-Zhihu](https://img.shields.io/github/stars/StaryMoon/VSCode-Zhihu?style=flat&label=VSCode-Zhihu)](https://github.com/StaryMoon/VSCode-Zhihu)
+
+![Student Stats](https://student-stats-cards.vercel.app/api/student?name=Minghao%20Liu&school=Peking%20University%20%7C%20Image%20Restoration&github=StaryMoon&papers=3&projects=6&prs=6&anki=180&theme=light)
+
+## Focus
+
+- Image restoration and deraining, especially prompt-based continual restoration.
+- Research tooling for reading, writing, project pages, and reproducible demos.
+- macOS and VS Code utilities that turn daily workflows into small, usable products.
+
+## Selected Projects
+
+| Project | What it shows |
+|---|---|
+| [DailyDesk](https://github.com/StaryMoon/DailyDesk) | Native Swift/AppKit macOS glass desktop planner with recurring tasks, local rewards, and a tiny desktop pet. |
+| [VSCode-Zhihu](https://github.com/StaryMoon/VSCode-Zhihu) | Maintained fork of Zhihu On VSCode with login fixes, packaged VSIX releases, markdown publishing, answer drafting, and authenticated reading utilities. |
+| [student-stats-cards](https://github.com/StaryMoon/student-stats-cards) | GitHub profile cards for students: research, LeetCode, open-source PRs, study streaks, and academic signals. |
+| [Prompting-Rain-Off](https://github.com/StaryMoon/Prompting-Rain-Off) | Project page for "Prompting Rain Off: Evolving Compact Dual Prompts for Continual De-Raining". |
+| [StaryMoon.github.io](https://github.com/StaryMoon/StaryMoon.github.io) | Personal academic homepage for publications, projects, and technical writing. |
+| [SpeedCraftLab](https://github.com/StaryMoon/SpeedCraftLab) | Browser lab for reaction time, visual scanning, CPS, and niche puzzle-game rhythm training. |
+
+## Research Threads
+
+- Continual image restoration under changing degradations.
+- Compact prompts and parameter-efficient adaptation.
+- Deraining, rainy-domain adaptation, and restoration-oriented project pages.
+- Practical tooling for paper demos, personal academic sites, and lightweight research distribution.
+
+## Open Source Footprints
+
+- Merged upstream PR: [nilbuild/developer-roadmap#10037](https://github.com/nilbuild/developer-roadmap/pull/10037).
+- Public maintainer-style releases for [VSCode-Zhihu](https://github.com/StaryMoon/VSCode-Zhihu/releases) and [DailyDesk](https://github.com/StaryMoon/DailyDesk/releases).
+- Active focus on making small tools understandable through clean README files, screenshots, release notes, and reproducible build steps.
+
+## Current Stack
+
+Swift/AppKit, TypeScript, JavaScript, Python, PyTorch, HTML/CSS, GitHub Actions, VS Code extension tooling.
+
+## Stats
+
+![Minghao's GitHub stats](https://github-readme-stats.vercel.app/api?username=StaryMoon&show_icons=true&hide_border=true&rank_icon=github)
+
+------
+Credit: [StaryMoon](https://github.com/StaryMoon)
+
+Last Edited on: 04/06/2026


### PR DESCRIPTION
## Summary

Adds the StaryMoon GitHub profile README template following the repository contribution guide:

- creates `templates/StaryMoon.md`
- adds `StaryMoon` to `_sidebar.md`
- includes credit and last edited date

The template highlights a research/student profile with project tables, dynamic student stats, open-source footprints, and GitHub stats.
